### PR TITLE
Adding standard sg for web traffic + documentation.

### DIFF
--- a/securitygroups/README.md
+++ b/securitygroups/README.md
@@ -15,7 +15,7 @@ with a rule to allow traffic for customer specific setup, e.g. Datadog.
 ## Generated resources
 - security groups:
   * `sg_all`: Security group that needs to be attached to all instances
-  * `sg_web`: Security group that allows incoming http/https traffic
+  * `sg_web_public`: Security group that allows incoming http/https traffic for public facing web servers
 
 ## Required variables
 

--- a/securitygroups/README.md
+++ b/securitygroups/README.md
@@ -9,12 +9,13 @@ on the other hand.
 
 The `sg_all` security group is a good example for this: the reusable part with 
 outgoing `ntp` and `https` access is in this module, but by exposing the security group, 
-a very specfic TF customer module can extend `sg_all`
+a very specific TF customer module can extend `sg_all`
 with a rule to allow traffic for customer specific setup, e.g. Datadog.
 
 ## Generated resources
 - security groups:
   * `sg_all`: Security group that needs to be attached to all instances
+  * `sg_web`: Security group that allows incoming http/https traffic
 
 ## Required variables
 

--- a/securitygroups/outputs.tf
+++ b/securitygroups/outputs.tf
@@ -1,3 +1,7 @@
 output "sg_all_id" {
   value = "${aws_security_group.sg_all.id}"
 }
+
+output "sg_web_id" {
+  value = "${aws_security_group.sg_web.id}"
+}

--- a/securitygroups/outputs.tf
+++ b/securitygroups/outputs.tf
@@ -2,6 +2,6 @@ output "sg_all_id" {
   value = "${aws_security_group.sg_all.id}"
 }
 
-output "sg_web_id" {
-  value = "${aws_security_group.sg_web.id}"
+output "sg_web_public_id" {
+  value = "${aws_security_group.sg_web_public.id}"
 }

--- a/securitygroups/web.tf
+++ b/securitygroups/web.tf
@@ -1,0 +1,32 @@
+# Create common security group
+resource "aws_security_group" "sg_web" {
+  name        = "sg_web_${var.project}_${var.environment}"
+  description = "General security group to allow incoming web traffic"
+  vpc_id      = "${var.vpc_id}"
+
+  tags {
+    Name        = "${var.project}-${var.environment}-sg_web"
+    Environment = "${var.environment}"
+    Project     = "${var.project}"
+  }
+}
+
+# Accept incoming http connections
+resource "aws_security_group_rule" "sg_host_in_http" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.sg_web.id}"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+# Accept incoming https connections
+resource "aws_security_group_rule" "sg_host_in_https" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.sg_web.id}"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/securitygroups/web.tf
+++ b/securitygroups/web.tf
@@ -1,11 +1,11 @@
 # Create common security group
-resource "aws_security_group" "sg_web" {
+resource "aws_security_group" "sg_web_public" {
   name        = "sg_web_${var.project}_${var.environment}"
   description = "General security group to allow incoming web traffic"
   vpc_id      = "${var.vpc_id}"
 
   tags {
-    Name        = "${var.project}-${var.environment}-sg_web"
+    Name        = "${var.project}-${var.environment}-sg_web_public"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }
@@ -14,7 +14,7 @@ resource "aws_security_group" "sg_web" {
 # Accept incoming http connections
 resource "aws_security_group_rule" "sg_host_in_http" {
   type              = "ingress"
-  security_group_id = "${aws_security_group.sg_web.id}"
+  security_group_id = "${aws_security_group.sg_web_public.id}"
   from_port         = 80
   to_port           = 80
   protocol          = "tcp"
@@ -24,7 +24,7 @@ resource "aws_security_group_rule" "sg_host_in_http" {
 # Accept incoming https connections
 resource "aws_security_group_rule" "sg_host_in_https" {
   type              = "ingress"
-  security_group_id = "${aws_security_group.sg_web.id}"
+  security_group_id = "${aws_security_group.sg_web_public.id}"
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"


### PR DESCRIPTION
Part of the `terraform apply` for viafutura:

```
+ module.general_security_groups.aws_security_group.sg_web
    description:      "General security group to allow incoming web traffic"
    egress.#:         "<computed>"
    ingress.#:        "<computed>"
    name:             "sg_web_viafutura_staging"
    owner_id:         "<computed>"
    tags.%:           "3"
    tags.Environment: "staging"
    tags.Name:        "viafutura-staging-sg_web"
    tags.Project:     "viafutura"
    vpc_id:           "vpc-2877064c"

+ module.general_security_groups.aws_security_group_rule.sg_host_in_http
    cidr_blocks.#:            "1"
    cidr_blocks.0:            "0.0.0.0/0"
    from_port:                "80"
    protocol:                 "tcp"
    security_group_id:        "<computed>"
    self:                     "false"
    source_security_group_id: "<computed>"
    to_port:                  "80"
    type:                     "ingress"

+ module.general_security_groups.aws_security_group_rule.sg_host_in_https
    cidr_blocks.#:            "1"
    cidr_blocks.0:            "0.0.0.0/0"
    from_port:                "443"
    protocol:                 "tcp"
    security_group_id:        "<computed>"
    self:                     "false"
    source_security_group_id: "<computed>"
    to_port:                  "443"
    type:                     "ingress"