### PR TITLE
Allow Icinga ping to hosts within a VPC

### DIFF
--- a/securitygroups/all.tf
+++ b/securitygroups/all.tf
@@ -1,3 +1,7 @@
+data "aws_vpc" "vpc_info" {
+  id = "${var.vpc_id}"
+}
+
 # Create common security group
 resource "aws_security_group" "sg_all" {
   name        = "sg_all_${var.project}_${var.environment}"
@@ -40,4 +44,13 @@ resource "aws_security_group_rule" "sg_bastion_out_https" {
   to_port           = 443
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "sg_bastion_ingress_ping" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.sg_all.id}"
+  from_port         = "-1"
+  to_port           = "-1"
+  protocol          = "icmp"
+  cidr_blocks       = ["${data.aws_vpc.vpc_info.cidr_block}"]
 }


### PR DESCRIPTION
TF plan used by Viafutura:

```
+ module.general_security_groups.aws_security_group_rule.sg_bastion_ingress_ping
    cidr_blocks.#:            "1"
    cidr_blocks.0:            "10.23.0.0/16"
    from_port:                "-1"
    protocol:                 "icmp"
    security_group_id:        "sg-d4d775b2"
    self:                     "false"
    source_security_group_id: "<computed>"
    to_port:                  "-1"
    type:                     "ingress"
```