### PR TITLE
Also allow ping to be sent to hosts within the VPC.

### DIFF
--- a/securitygroups/all.tf
+++ b/securitygroups/all.tf
@@ -46,8 +46,17 @@ resource "aws_security_group_rule" "sg_bastion_out_https" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "sg_bastion_ingress_ping" {
+resource "aws_security_group_rule" "sg_all_ingress_ping" {
   type              = "ingress"
+  security_group_id = "${aws_security_group.sg_all.id}"
+  from_port         = "-1"
+  to_port           = "-1"
+  protocol          = "icmp"
+  cidr_blocks       = ["${data.aws_vpc.vpc_info.cidr_block}"]
+}
+
+resource "aws_security_group_rule" "sg_all_egress_ping" {
+  type              = "egress"
   security_group_id = "${aws_security_group.sg_all.id}"
   from_port         = "-1"
   to_port           = "-1"


### PR DESCRIPTION
TF plan used for Viafutura:

```
+ module.general_security_groups.aws_security_group_rule.sg_all_egress_ping
    cidr_blocks.#:            "1"
    cidr_blocks.0:            "10.23.0.0/16"
    from_port:                "-1"
    protocol:                 "icmp"
    security_group_id:        "sg-d4d775b2"
    self:                     "false"
    source_security_group_id: "<computed>"
    to_port:                  "-1"
    type:                     "egress"

Plan: 1 to add, 0 to change, 0 to destroy.
```