### PR TITLE
Adding the Icinga Satellite Server security group

### DIFF
--- a/securitygroups/icinga_satellite/main.tf
+++ b/securitygroups/icinga_satellite/main.tf
@@ -1,0 +1,57 @@
+resource "aws_security_group" "sg_icinga_satellite" {
+  name = "sg_icinga_satellite_${var.project}_${var.environment}"
+  description = "Icinga Satellite Security Group"
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name        = "${var.project}-${var.environment}-sg_icinga_sattelite"
+    Environment = "${var.environment}"
+    Project     = "${var.project}"
+  }
+}
+
+# Allow incoming NRPE check from icinga2
+resource "aws_security_group_rule" "icinga_nrpe_into_tools01" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.sg_icinga_satellite.id}"
+  from_port         = "5666"
+  to_port           = "5666"
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.icinga_master_ip}"]
+}
+
+resource "aws_security_group_rule" "icinga_into_tools01" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.sg_icinga_satellite.id}"
+  from_port         = "5667"
+  to_port           = "5667"
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.icinga_master_ip}"]
+}
+
+resource "aws_security_group_rule" "icinga_outside1_from_tools01" {
+  type              = "egress"
+  security_group_id = "${aws_security_group.sg_icinga_satellite.id}"
+  from_port         = "5665"
+  to_port           = "5665"
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.icinga_master_ip}"]
+}
+
+resource "aws_security_group_rule" "icinga_outside2_from_tools01" {
+  type              = "egress"
+  security_group_id = "${aws_security_group.sg_icinga_satellite.id}"
+  from_port         = "6379"
+  to_port           = "6379"
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.icinga_master_ip}"]
+}
+
+resource "aws_security_group_rule" "icinga_outside3_from_tools01" {
+  type              = "egress"
+  security_group_id = "${aws_security_group.sg_icinga_satellite.id}"
+  from_port         = "9418"
+  to_port           = "9418"
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.icinga_master_ip}"]
+}

--- a/securitygroups/icinga_satellite/outputs.tf
+++ b/securitygroups/icinga_satellite/outputs.tf
@@ -1,0 +1,3 @@
+output "sg_icinga_satellite_id" {
+  value = "${aws_security_group.sg_icinga_satellite.id}"
+}

--- a/securitygroups/icinga_satellite/variables.tf
+++ b/securitygroups/icinga_satellite/variables.tf
@@ -1,0 +1,16 @@
+variable "vpc_id" {
+  description = "ID of the VPC where to deploy in"
+}
+
+variable "environment" {
+  description = "How do you want to call your environment, this is helpful if you have more than 1 VPC."
+  default     = "production"
+}
+
+variable "project" {
+  description = "The current project"
+}
+
+variable "icinga_master_ip" {
+  description = "IP of the Icinga master, in CIDR/32 notation"
+}


### PR DESCRIPTION
TF plan output when used for Sweepbright icinga satellite:
```
+ module.vpc.sg_icinga_satellite.aws_security_group.sg_icinga_satellite
    description:      "Icinga Satellite Security Group"
    egress.#:         "<computed>"
    ingress.#:        "<computed>"
    name:             "sg_icinga_satellite_sweepbright_beta"
    owner_id:         "<computed>"
    tags.%:           "3"
    tags.Environment: "beta"
    tags.Name:        "sweepbright-beta-sg_icinga_sattelite"
    tags.Project:     "sweepbright"
    vpc_id:           "vpc-01108b65"

+ module.vpc.sg_icinga_satellite.aws_security_group_rule.icinga_into_tools01
    cidr_blocks.#:            "1"
    cidr_blocks.0:            "52.18.75.113/32"
    from_port:                "5667"
    protocol:                 "tcp"
    security_group_id:        "<computed>"
    self:                     "false"
    source_security_group_id: "<computed>"
    to_port:                  "5667"
    type:                     "ingress"

+ module.vpc.sg_icinga_satellite.aws_security_group_rule.icinga_nrpe_into_tools01
    cidr_blocks.#:            "1"
    cidr_blocks.0:            "52.18.75.113/32"
    from_port:                "5666"
    protocol:                 "tcp"
    security_group_id:        "<computed>"
    self:                     "false"
    source_security_group_id: "<computed>"
    to_port:                  "5666"
    type:                     "ingress"

+ module.vpc.sg_icinga_satellite.aws_security_group_rule.icinga_outside1_from_tools01
    cidr_blocks.#:            "1"
    cidr_blocks.0:            "52.18.75.113/32"
    from_port:                "5665"
    protocol:                 "tcp"
    security_group_id:        "<computed>"
    self:                     "false"
    source_security_group_id: "<computed>"
    to_port:                  "5665"
    type:                     "egress"

+ module.vpc.sg_icinga_satellite.aws_security_group_rule.icinga_outside2_from_tools01
    cidr_blocks.#:            "1"
    cidr_blocks.0:            "52.18.75.113/32"
    from_port:                "6379"
    protocol:                 "tcp"
    security_group_id:        "<computed>"
    self:                     "false"
    source_security_group_id: "<computed>"
    to_port:                  "6379"
    type:                     "egress"

+ module.vpc.sg_icinga_satellite.aws_security_group_rule.icinga_outside3_from_tools01
    cidr_blocks.#:            "1"
    cidr_blocks.0:            "52.18.75.113/32"
    from_port:                "9418"
    protocol:                 "tcp"
    security_group_id:        "<computed>"
    self:                     "false"
    source_security_group_id: "<computed>"
    to_port:                  "9418"
    type:                     "egress"

```