### PR TITLE
Adding Availability Zone tag to subnets.

### DIFF
--- a/subnets/main.tf
+++ b/subnets/main.tf
@@ -12,7 +12,7 @@ resource "aws_subnet" "subnets" {
   cidr_block        = "${cidrsubnet(var.cidr,var.newbits,var.netnum+count.index)}"
   availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags = "${merge("${var.tags}",map("Name", "${var.project}-${var.visibility}-${var.role}-${element(data.aws_availability_zones.available.names, count.index)}", "Environment", "${var.environment}", "Project", "${var.project}", "Role", "${var.role}", "Visibility", "${var.visibility}"))}"
+  tags = "${merge("${var.tags}",map("Name", "${var.project}-${var.visibility}-${var.role}-${element(data.aws_availability_zones.available.names, count.index)}", "Environment", "${var.environment}", "Project", "${var.project}", "Role", "${var.role}", "Visibility", "${var.visibility}", "AvailabilityZone", element(data.aws_availability_zones.available.names, count.index)))}"
 }
 
 resource "aws_route_table_association" "subnet_association" {


### PR DESCRIPTION
Allows for filtering on the availability zone in the `aws_subnet_ids` datasource. Further down, it allows me to have correct placement between an `aws_instance` and an `aws_ebs_volume` in the same AZ using `aws_volume_attachment`.

TF plan as part of the `vpc` module:

```
Terraform will perform the following actions:

  ~ module.vpc.module.private_app_subnets.aws_subnet.subnets[0]
      tags.%:                "5" => "6"
      tags.AvailabilityZone: "" => "eu-west-1a"

  ~ module.vpc.module.private_app_subnets.aws_subnet.subnets[1]
      tags.%:                "5" => "6"
      tags.AvailabilityZone: "" => "eu-west-1b"

  ~ module.vpc.module.private_app_subnets.aws_subnet.subnets[2]
      tags.%:                "5" => "6"
      tags.AvailabilityZone: "" => "eu-west-1c"

  ~ module.vpc.module.private_db_subnets.aws_subnet.subnets[0]
      tags.%:                "5" => "6"
      tags.AvailabilityZone: "" => "eu-west-1a"

  ~ module.vpc.module.private_db_subnets.aws_subnet.subnets[1]
      tags.%:                "5" => "6"
      tags.AvailabilityZone: "" => "eu-west-1b"

  ~ module.vpc.module.private_db_subnets.aws_subnet.subnets[2]
      tags.%:                "5" => "6"
      tags.AvailabilityZone: "" => "eu-west-1c"

  ~ module.vpc.module.public_lb_subnets.aws_subnet.subnets[0]
      tags.%:                "5" => "6"
      tags.AvailabilityZone: "" => "eu-west-1a"

  ~ module.vpc.module.public_lb_subnets.aws_subnet.subnets[1]
      tags.%:                "5" => "6"
      tags.AvailabilityZone: "" => "eu-west-1b"

  ~ module.vpc.module.public_lb_subnets.aws_subnet.subnets[2]
      tags.%:                "5" => "6"
      tags.AvailabilityZone: "" => "eu-west-1c"

  ~ module.vpc.module.public_nat-bastion_subnets.aws_subnet.subnets
      tags.%:                "5" => "6"
      tags.AvailabilityZone: "" => "eu-west-1a"


Plan: 0 to add, 10 to change, 0 to destroy.
```