### PR TITLE
Set the AZ in the NAT gateways name for easier identification

### DIFF
--- a/nat_gateway/main.tf
+++ b/nat_gateway/main.tf
@@ -3,10 +3,19 @@ resource "aws_eip" "nat_gateway" {
   vpc = true
 }
 
+data "aws_subnet" "ngw_subnets" {
+  count = "${var.number_nat_gateways}"
+  id    = "${var.public_subnets[count.index]}"
+}
+
 resource "aws_nat_gateway" "gateway" {
   count="${var.number_nat_gateways}"
   allocation_id = "${aws_eip.nat_gateway.*.id[count.index]}"
   subnet_id = "${var.public_subnets[count.index]}"
+
+  tags {
+    Name = "${data.aws_subnet.ngw_subnets.*.availability_zone[count.index]}"
+  }
 }
 
 resource "aws_route" "r" {


### PR DESCRIPTION
This adds the `Name` tag to the created NAT gateways with the corresponding availability zone as its value.