### PR TITLE
Add the option to provide extra tags for NAT gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Creates a nat gateway and automatically adds a route table to the route tables p
 * [`private_route_tables`]: List(required): List of private route tables that require the nat gateway [NOTE the number of nat gateways should match the number of private routes]
 * [`number_nat_gateways`]: String(optional):  Number of nat gateways required
 * [`public_subnets`]: List(required): The subnets where we are going to create/deploy the NAT gateways
+* [`tags`]: Map(optional): optional tags
 
 ### Output
 

--- a/nat_gateway/main.tf
+++ b/nat_gateway/main.tf
@@ -13,9 +13,7 @@ resource "aws_nat_gateway" "gateway" {
   allocation_id = "${aws_eip.nat_gateway.*.id[count.index]}"
   subnet_id = "${var.public_subnets[count.index]}"
 
-  tags {
-    Name = "${data.aws_subnet.ngw_subnets.*.availability_zone[count.index]}"
-  }
+  tags = "${merge(var.tags, map("Name", data.aws_subnet.ngw_subnets.*.availability_zone[count.index]))}"
 }
 
 resource "aws_route" "r" {

--- a/nat_gateway/variables.tf
+++ b/nat_gateway/variables.tf
@@ -7,3 +7,9 @@ variable "number_nat_gateways" {
 variable "public_subnets" {
   type = "list"
 }
+
+variable "tags" {
+  type        = "map"
+  description = "Optional extra tags"
+  default     = {}
+}


### PR DESCRIPTION
This adds an optional variable in the NAT gateway module, to be able to set extra tags in AWS.
This is needed when creating NAT gateways that will be shared with a kops created k8s cluster, as kops will add some tags that need to be also set in terraform.