### PR TITLE
Add private K8s subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ It will also create the required route tables for the private subnets. The priva
 |------|-------------|:----:|:-----:|:-----:|
 | amount\_private\_app\_subnets | Amount of subnets you need | number | `3` | no |
 | amount\_private\_db\_subnets | Amount of subnets you need | number | `3` | no |
+| amount\_private\_k8s\_subnets | Amount of subnets you need | number | `0` | no |
 | amount\_private\_management\_subnets | Amount of subnets you need | number | `0` | no |
 | amount\_public\_lb\_subnets | Amount of subnets you need | number | `3` | no |
 | amount\_public\_nat-bastion\_subnets | Amount of subnets you need | number | `1` | no |
@@ -92,15 +93,18 @@ It will also create the required route tables for the private subnets. The priva
 | environment | How do you want to call your environment, this is helpful if you have more than 1 VPC. | string | `"production"` | no |
 | extra\_tags\_private\_app | Private app subnets extra tags | map | `<map>` | no |
 | extra\_tags\_private\_db | Private database subnets extra tags | map | `<map>` | no |
+| extra\_tags\_private\_k8s | Private K8s subnets extra tags | map | `<map>` | no |
 | extra\_tags\_private\_management | Private management subnets extra tags | map | `<map>` | no |
 | extra\_tags\_public\_lb | Public load balancer subnets extra tags | map | `<map>` | no |
 | extra\_tags\_public\_nat-bastion | Public nat/bastion subnets extra tags | map | `<map>` | no |
 | extra\_tags\_vpc | VPC extra tags | map | `<map>` | no |
-| netnum\_private\_app | First number of subnet to start of for private_app subnets | string | `"20"` | no |
-| netnum\_private\_db | First number of subnet to start of for private_db subnets | string | `"30"` | no |
-| netnum\_private\_management | First number of subnet to start of for private_management subnets | string | `"200"` | no |
-| netnum\_public\_lb | First number of subnet to start of for public_lb subnets | string | `"10"` | no |
-| netnum\_public\_nat-bastion | First number of subnet to start of for public_nat-bastion subnets | string | `"0"` | no |
+| netnum\_private\_app | First number of subnet to start of for private_app subnets | number | `20` | no |
+| netnum\_private\_db | First number of subnet to start of for private_db subnets | number | `30` | no |
+| netnum\_private\_k8s | Netnum to use for determining the offset for private_k8s subnets. Using the default of `8` while considering `newbits = 4`, with an example `cidr_block = 10.0.0.0/16`, the first subnet would be: `10.0.128.0/20` | number | `8` | no |
+| netnum\_private\_management | First number of subnet to start of for private_management subnets | number | `200` | no |
+| netnum\_public\_lb | First number of subnet to start of for public_lb subnets | number | `10` | no |
+| netnum\_public\_nat-bastion | First number of subnet to start of for public_nat-bastion subnets | number | `0` | no |
+| newbits\_private\_k8s | Newbits to use as additional bits with which to extend the `cidr_block` for private_k8s subnets | number | `4` | no |
 | number\_private\_rt | The desired number of private route tables. In case we want one per AZ we can change this value. | number | `1` | no |
 | project | The current project | string | n/a | yes |
 | tags | Optional Tags | map | `<map>` | no |
@@ -112,6 +116,7 @@ It will also create the required route tables for the private subnets. The priva
 | default\_network\_acl\_id | Id of the default network acl |
 | private\_app\_subnets | List of the private_app subnets id created |
 | private\_db\_subnets | List of the private_db subnets id created |
+| private\_k8s\_subnets | List of the private_k8s subnets id created |
 | private\_management\_subnets | List of the private_management subnets id created |
 | private\_rts | List of the ids of the private route tables created |
 | public\_lb\_subnets | List of the public_lb subnets id created |

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -74,6 +74,22 @@ module "private_db_subnets" {
   num_route_tables = var.number_private_rt
 }
 
+module "private_k8s_subnets" {
+  source           = "../subnets"
+  num_subnets      = var.amount_private_k8s_subnets
+  visibility       = "private"
+  role             = "k8s"
+  cidr             = var.cidr_block
+  newbits          = var.newbits_private_k8s
+  netnum           = var.netnum_private_k8s
+  vpc_id           = aws_vpc.main.id
+  environment      = var.environment
+  project          = var.project
+  tags             = merge(var.extra_tags_private_k8s, var.tags)
+  route_tables     = aws_route_table.private.*.id
+  num_route_tables = var.number_private_rt
+}
+
 module "private_management_subnets" {
   source           = "../subnets"
   num_subnets      = var.amount_private_management_subnets

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -23,6 +23,11 @@ output "private_db_subnets" {
   value       = module.private_db_subnets.ids
 }
 
+output "private_k8s_subnets" {
+  description = "List of the private_k8s subnets id created"
+  value       = module.private_k8s_subnets.ids
+}
+
 output "private_management_subnets" {
   description = "List of the private_management subnets id created"
   value       = module.private_management_subnets.ids

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -1,4 +1,16 @@
+variable "environment" {
+  type        = string
+  description = "How do you want to call your environment, this is helpful if you have more than 1 VPC."
+  default     = "production"
+}
+
+variable "project" {
+  type        = string
+  description = "The current project"
+}
+
 variable "cidr_block" {
+  type        = string
   description = "CIDR block you want to have in your VPC"
 }
 
@@ -26,19 +38,16 @@ variable "amount_private_db_subnets" {
   default     = 3
 }
 
-variable "amount_private_management_subnets" {
+variable "amount_private_k8s_subnets" {
   type        = number
   description = "Amount of subnets you need"
   default     = 0
 }
 
-variable "environment" {
-  description = "How do you want to call your environment, this is helpful if you have more than 1 VPC."
-  default     = "production"
-}
-
-variable "project" {
-  description = "The current project"
+variable "amount_private_management_subnets" {
+  type        = number
+  description = "Amount of subnets you need"
+  default     = 0
 }
 
 variable "number_private_rt" {
@@ -60,6 +69,16 @@ variable "netnum_private_app" {
 variable "netnum_private_db" {
   description = "First number of subnet to start of for private_db subnets"
   default     = "30"
+}
+
+variable "newbits_private_k8s" {
+  description = "Newbits to use as additional bits with which to extend the `cidr_block` for private_k8s subnets"
+  default     = "4"
+}
+
+variable "netnum_private_k8s" {
+  description = "Netnum to use for determining the offset for private_k8s subnets. Using the default of `8` while considering `newbits = 4`, with an example `cidr_block = 10.0.0.0/16`, the first subnet would be: `10.0.128.0/20`"
+  default     = "8"
 }
 
 variable "netnum_private_management" {
@@ -105,6 +124,12 @@ variable "extra_tags_private_app" {
 variable "extra_tags_private_db" {
   type        = map(string)
   description = "Private database subnets extra tags"
+  default     = {}
+}
+
+variable "extra_tags_private_k8s" {
+  type        = map(string)
+  description = "Private K8s subnets extra tags"
   default     = {}
 }
 

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -57,38 +57,45 @@ variable "number_private_rt" {
 }
 
 variable "netnum_public_lb" {
+  type        = number
   description = "First number of subnet to start of for public_lb subnets"
-  default     = "10"
+  default     = 10
 }
 
 variable "netnum_private_app" {
+  type        = number
   description = "First number of subnet to start of for private_app subnets"
-  default     = "20"
+  default     = 20
 }
 
 variable "netnum_private_db" {
+  type        = number
   description = "First number of subnet to start of for private_db subnets"
-  default     = "30"
+  default     = 30
 }
 
 variable "newbits_private_k8s" {
+  type        = number
   description = "Newbits to use as additional bits with which to extend the `cidr_block` for private_k8s subnets"
-  default     = "4"
+  default     = 4
 }
 
 variable "netnum_private_k8s" {
+  type        = number
   description = "Netnum to use for determining the offset for private_k8s subnets. Using the default of `8` while considering `newbits = 4`, with an example `cidr_block = 10.0.0.0/16`, the first subnet would be: `10.0.128.0/20`"
-  default     = "8"
+  default     = 8
 }
 
 variable "netnum_private_management" {
+  type        = number
   description = "First number of subnet to start of for private_management subnets"
-  default     = "200"
+  default     = 200
 }
 
 variable "netnum_public_nat-bastion" {
+  type        = number
   description = "First number of subnet to start of for public_nat-bastion subnets"
-  default     = "0"
+  default     = 0
 }
 
 variable "tags" {


### PR DESCRIPTION
This change adds a new group of sunets, specific for running K8s (EKS workers). By default they'll be setup as larger `/20` (`newbits=4`) subnets compared to the `/24` (`newbits=8`) of other subnets (considering `/16` as VPC CIDR).

Related story: skyscrapers/engineering#301

```
  # module.vpc.module.private_k8s_subnets.aws_route_table_association.subnet_association[0] will be created
  + resource "aws_route_table_association" "subnet_association" {
      + id             = (known after apply)
      + route_table_id = "rtb-470eda20"
      + subnet_id      = (known after apply)
    }

  # module.vpc.module.private_k8s_subnets.aws_route_table_association.subnet_association[1] will be created
  + resource "aws_route_table_association" "subnet_association" {
      + id             = (known after apply)
      + route_table_id = "rtb-470eda20"
      + subnet_id      = (known after apply)
    }

  # module.vpc.module.private_k8s_subnets.aws_route_table_association.subnet_association[2] will be created
  + resource "aws_route_table_association" "subnet_association" {
      + id             = (known after apply)
      + route_table_id = "rtb-470eda20"
      + subnet_id      = (known after apply)
    }

  # module.vpc.module.private_k8s_subnets.aws_subnet.subnets[0] will be created
  + resource "aws_subnet" "subnets" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "eu-west-1a"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.12.128.0/20"
      + id                              = (known after apply)
      + ipv6_cidr_block                 = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags                            = {
          + "AvailabilityZone" = "eu-west-1a"
          + "Environment"      = "production"
          + "Name"             = "skyscrapers-private-k8s-eu-west-1a"
          + "Project"          = "skyscrapers"
          + "Role"             = "k8s"
          + "Visibility"       = "private"
        }
      + vpc_id                          = "vpc-70526f14"
    }

  # module.vpc.module.private_k8s_subnets.aws_subnet.subnets[1] will be created
  + resource "aws_subnet" "subnets" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "eu-west-1b"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.12.144.0/20"
      + id                              = (known after apply)
      + ipv6_cidr_block                 = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags                            = {
          + "AvailabilityZone" = "eu-west-1b"
          + "Environment"      = "production"
          + "Name"             = "skyscrapers-private-k8s-eu-west-1b"
          + "Project"          = "skyscrapers"
          + "Role"             = "k8s"
          + "Visibility"       = "private"
        }
      + vpc_id                          = "vpc-70526f14"
    }

  # module.vpc.module.private_k8s_subnets.aws_subnet.subnets[2] will be created
  + resource "aws_subnet" "subnets" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "eu-west-1c"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.12.160.0/20"
      + id                              = (known after apply)
      + ipv6_cidr_block                 = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags                            = {
          + "AvailabilityZone" = "eu-west-1c"
          + "Environment"      = "production"
          + "Name"             = "skyscrapers-private-k8s-eu-west-1c"
          + "Project"          = "skyscrapers"
          + "Role"             = "k8s"
          + "Visibility"       = "private"
        }
      + vpc_id                          = "vpc-70526f14"
    }

Plan: 6 to add, 0 to change, 0 to destroy.
```