### PR TITLE
Allow overriding which AZs to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,24 +31,15 @@ module "nat_gateway" {
 
 Creates a number of subnets and divides them in different parts based on the input params
 
-### Available variables
+### Inputs
 
-* [`cidr`]: String(required): the CIDR to be divided into subnets  
-* [`newbits`]: String(optional): default to 8. For details see https://www.terraform.io/docs/configuration/interpolation.html#cidrsubnet_iprange_newbits_netnum_
-* [`netnum`]: String(optional): default to 0. First number of subnet to start of (ex I want a 10.1,10.2,10.3 subnet I specify 1)
-* [`vpc_id`]: String(required): the VPC ID where we want to create the subnets
-* [`role`]: String(required): the role of the subnets. Example values are `lb`, `db` and `app`.
-* [`visibility`]: String(required): the visibility of the subnets. Valid values are `public` and `private`
-* [`tags`]: Map(optional): optional tags
-* [`project`]: String(required): the name of the project these subnets belong to
-* [`environment`]: String(required): the name of the environment these subnets belong to (prod,stag,dev)
-* [`num_subnets`]: String(optional): default to 3. the number of subnets we want to create
-* [`route_tables`]: List(string)(optional): the list of route tables to associate to the created subnet. This will associate the route table to the created subnet sequentially. If the subnet number is greater than the number of route tables, the route table will be selected sing a standard mod algorithm
-* [`num_route_tables`]: Number(optional): default to 0. the number of route tables passed in route_tables. NOTE: this is due to a bug in terraform that cannot iterate over count param
+**TODO** once terraform-docs properly supports 0.12...
 
-### Output
+### Outputs
 
-* [`ids`]: List: the ids of the subnets created
+| Name | Description |
+|------|-------------|
+| ids  | the ids of the subnets created |
 
 ### Example
 
@@ -79,10 +70,11 @@ This module will create a vpc with the option to specify 4 types of subnets:
 
 It will also create the required route tables for the private subnets. The private_app and private_db subnets are private subnets.
 
-### Available variables
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| availability\_zones | List of AZs to use for the subnets. Defaults to all available AZs when not specified (looped over sequentially for the amount of subnets) | list(string) | `null` | no |
 | amount\_private\_app\_subnets | Amount of subnets you need | number | `3` | no |
 | amount\_private\_db\_subnets | Amount of subnets you need | number | `3` | no |
 | amount\_private\_management\_subnets | Amount of subnets you need | number | `0` | no |
@@ -105,7 +97,7 @@ It will also create the required route tables for the private subnets. The priva
 | project | The current project | string | n/a | yes |
 | tags | Optional Tags | map | `<map>` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/subnets/main.tf
+++ b/subnets/main.tf
@@ -2,21 +2,25 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
+locals {
+  availability_zones = var.availability_zones != null ? var.availability_zones : data.aws_availability_zones.available.names
+}
+
 resource "aws_subnet" "subnets" {
   count             = var.num_subnets
   vpc_id            = var.vpc_id
   cidr_block        = cidrsubnet(var.cidr, var.newbits, var.netnum + count.index)
-  availability_zone = element(data.aws_availability_zones.available.names, count.index)
+  availability_zone = local.availability_zones[count.index]
 
   tags = merge(
     var.tags,
     {
-      "Name"             = "${var.project}-${var.visibility}-${var.role}-${element(data.aws_availability_zones.available.names, count.index)}"
+      "Name"             = "${var.project}-${var.visibility}-${var.role}-${local.availability_zones[count.index]}"
       "Environment"      = var.environment
       "Project"          = var.project
       "Role"             = var.role
       "Visibility"       = var.visibility
-      "AvailabilityZone" = element(data.aws_availability_zones.available.names, count.index)
+      "AvailabilityZone" = local.availability_zones[count.index]
     },
   )
 }

--- a/subnets/variables.tf
+++ b/subnets/variables.tf
@@ -1,52 +1,71 @@
 variable "cidr" {
+  description = "CIDR block you use in your VPC"
+  type        = string
+}
+
+variable "availability_zones" {
+  description = "List of AZs to use for the subnets. Defaults to all available AZs when not specified (looped over sequentially for the amount of subnets)"
+  type        = list(string)
+  default     = null
 }
 
 variable "newbits" {
-  description = "see https://www.terraform.io/docs/configuration/interpolation.html#cidrsubnet_iprange_newbits_netnum_"
+  description = "Newbits to use for generating the subnets. For more information, see the [cidrsubnet function docs](https://www.terraform.io/docs/configuration/functions/cidrsubnet.html)"
+  type        = number
   default     = 8
 }
 
 variable "netnum" {
-  description = "first number of subnet to start of (ex I want a 10.1,10.2,10.3 subnet I specify 1) https://www.terraform.io/docs/configuration/interpolation.html#cidrsubnet_iprange_newbits_netnum_"
+  description = "Netnum to use for generating the EKS worker subnets. For more information, see the [cidrsubnet function docs](https://www.terraform.io/docs/configuration/functions/cidrsubnet.html)"
+  type        = number
   default     = 0
 }
 
 variable "vpc_id" {
-  description = "ID of the VPC where we want to deploy the subnet in"
+  description = "ID of the VPC where we want to deploy the subnet"
+  type        = string
 }
 
 variable "role" {
-  description = "Role of the subnets. Example values are `app`, `lb` and `db`"
+  description = "Role for the subnets. Example values are `app`, `lb`, `db`, ..."
+  type        = string
 }
 
 variable "visibility" {
-  description = "Visibility of this subnet. Valid values are `public` and `private`"
+  description = "Visibility of this subnet. Valid values are `public` or `private`"
+  type        = string
 }
 
 variable "tags" {
-  type        = map(string)
   description = "Optional Tags"
+  type        = map(string)
   default     = {}
 }
 
 variable "project" {
   description = "Project name"
+  type        = string
 }
 
 variable "environment" {
   description = "Environment name"
+  type        = string
 }
 
 variable "num_subnets" {
-  default = "3"
+  description = "Amount of subnets to create"
+  type        = number
+  default     = 3
 }
 
 variable "route_tables" {
-  type    = list(string)
-  default = []
+  description = "Route tables to attach the subnets to"
+  type        = list(string)
+  default     = []
 }
 
 variable "num_route_tables" {
-  type    = number
-  default = 0
+  description = "Amount of route tables to attach the subnets to"
+  type        = number
+  default     = 0
 }

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -15,78 +15,83 @@ resource "aws_vpc" "main" {
 }
 
 module "public_nat-bastion_subnets" {
-  source           = "../subnets"
-  num_subnets      = var.amount_public_nat-bastion_subnets
-  visibility       = "public"
-  role             = "nat-bastion"
-  cidr             = var.cidr_block
-  netnum           = var.netnum_public_nat-bastion
-  vpc_id           = aws_vpc.main.id
-  environment      = var.environment
-  project          = var.project
-  tags             = merge(var.extra_tags_public_nat-bastion, var.tags)
-  route_tables     = aws_route_table.public.*.id
-  num_route_tables = 1
+  source             = "../subnets"
+  availability_zones = var.availability_zones
+  num_subnets        = var.amount_public_nat-bastion_subnets
+  visibility         = "public"
+  role               = "nat-bastion"
+  cidr               = var.cidr_block
+  netnum             = var.netnum_public_nat-bastion
+  vpc_id             = aws_vpc.main.id
+  environment        = var.environment
+  project            = var.project
+  tags               = merge(var.extra_tags_public_nat-bastion, var.tags)
+  route_tables       = aws_route_table.public.*.id
+  num_route_tables   = 1
 }
 
 module "public_lb_subnets" {
-  source           = "../subnets"
-  num_subnets      = var.amount_public_lb_subnets
-  visibility       = "public"
-  role             = "lb"
-  cidr             = var.cidr_block
-  netnum           = var.netnum_public_lb
-  vpc_id           = aws_vpc.main.id
-  environment      = var.environment
-  project          = var.project
-  tags             = merge(var.extra_tags_public_lb, var.tags)
-  route_tables     = aws_route_table.public.*.id
-  num_route_tables = 1
+  source             = "../subnets"
+  availability_zones = var.availability_zones
+  num_subnets        = var.amount_public_lb_subnets
+  visibility         = "public"
+  role               = "lb"
+  cidr               = var.cidr_block
+  netnum             = var.netnum_public_lb
+  vpc_id             = aws_vpc.main.id
+  environment        = var.environment
+  project            = var.project
+  tags               = merge(var.extra_tags_public_lb, var.tags)
+  route_tables       = aws_route_table.public.*.id
+  num_route_tables   = 1
 }
 
 module "private_app_subnets" {
-  source           = "../subnets"
-  num_subnets      = var.amount_private_app_subnets
-  visibility       = "private"
-  role             = "app"
-  cidr             = var.cidr_block
-  netnum           = var.netnum_private_app
-  vpc_id           = aws_vpc.main.id
-  environment      = var.environment
-  project          = var.project
-  tags             = merge(var.extra_tags_private_app, var.tags)
-  route_tables     = aws_route_table.private.*.id
-  num_route_tables = var.number_private_rt
+  source             = "../subnets"
+  availability_zones = var.availability_zones
+  num_subnets        = var.amount_private_app_subnets
+  visibility         = "private"
+  role               = "app"
+  cidr               = var.cidr_block
+  netnum             = var.netnum_private_app
+  vpc_id             = aws_vpc.main.id
+  environment        = var.environment
+  project            = var.project
+  tags               = merge(var.extra_tags_private_app, var.tags)
+  route_tables       = aws_route_table.private.*.id
+  num_route_tables   = var.number_private_rt
 }
 
 module "private_db_subnets" {
-  source           = "../subnets"
-  num_subnets      = var.amount_private_db_subnets
-  visibility       = "private"
-  role             = "db"
-  cidr             = var.cidr_block
-  netnum           = var.netnum_private_db
-  vpc_id           = aws_vpc.main.id
-  environment      = var.environment
-  project          = var.project
-  tags             = merge(var.extra_tags_private_db, var.tags)
-  route_tables     = aws_route_table.private.*.id
-  num_route_tables = var.number_private_rt
+  source             = "../subnets"
+  availability_zones = var.availability_zones
+  num_subnets        = var.amount_private_db_subnets
+  visibility         = "private"
+  role               = "db"
+  cidr               = var.cidr_block
+  netnum             = var.netnum_private_db
+  vpc_id             = aws_vpc.main.id
+  environment        = var.environment
+  project            = var.project
+  tags               = merge(var.extra_tags_private_db, var.tags)
+  route_tables       = aws_route_table.private.*.id
+  num_route_tables   = var.number_private_rt
 }
 
 module "private_management_subnets" {
-  source           = "../subnets"
-  num_subnets      = var.amount_private_management_subnets
-  visibility       = "private"
-  role             = "management"
-  cidr             = var.cidr_block
-  netnum           = var.netnum_private_management
-  vpc_id           = aws_vpc.main.id
-  environment      = var.environment
-  project          = var.project
-  tags             = merge(var.extra_tags_private_management, var.tags)
-  route_tables     = aws_route_table.private.*.id
-  num_route_tables = var.number_private_rt
+  source             = "../subnets"
+  availability_zones = var.availability_zones
+  num_subnets        = var.amount_private_management_subnets
+  visibility         = "private"
+  role               = "management"
+  cidr               = var.cidr_block
+  netnum             = var.netnum_private_management
+  vpc_id             = aws_vpc.main.id
+  environment        = var.environment
+  project            = var.project
+  tags               = merge(var.extra_tags_private_management, var.tags)
+  route_tables       = aws_route_table.private.*.id
+  num_route_tables   = var.number_private_rt
 }
 
 # Create internet gateway

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -2,6 +2,12 @@ variable "cidr_block" {
   description = "CIDR block you want to have in your VPC"
 }
 
+variable "availability_zones" {
+  description = "List of AZs to use for the subnets. Defaults to all available AZs when not specified (looped over sequentially for the amount of subnets)"
+  type        = list(string)
+  default     = null
+}
+
 variable "amount_public_nat-bastion_subnets" {
   type        = number
   description = "Amount of subnets you need"


### PR DESCRIPTION
Sometimes we want to be able to specify which AZs to use for our subnets, especially in regions which have more of them available (eg us-east-1).