### PR TITLE
Add vpc peering module

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,56 @@ terraform state mv module.vpc.aws_route_table_association.private_db[1] module.v
 terraform state mv module.vpc.aws_route_table_association.private_db[2] module.vpc.module.private_db_subnets.aws_route_table_association.subnet_association[2]
 ```
 
+## vpc_peering
+
+Module to create a VPC peering connection between two VPCs. It creates the needed resources on both ends of the peering connection, thus it requires two different AWS providers.
+
+It also creates the routing between the two VPCs if the route tables are provided.
+
+### Requirements
+
+No requirements.
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| aws.source | n/a |
+| aws.target | n/a |
+
+### Modules
+
+No Modules.
+
+### Resources
+
+| Name |
+|------|
+| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) |
+| [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) |
+| [aws_vpc_peering_connection_options](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_options) |
+| [aws_vpc_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| source_name | Name of the source VPC | `string` | n/a | yes |
+| source_route_table_ids | List of route table IDs from the source VPC that should be routable to the target VPC | `list(string)` | n/a | yes |
+| source_vpc_id | ID of the source VPC | `string` | n/a | yes |
+| target_account_id | AWS account id of the target VPC | `string` | n/a | yes |
+| target_name | Name of the target VPC | `string` | n/a | yes |
+| target_route_table_ids | List of route table IDs from the target VPC that should be routable to the source VPC | `list(string)` | n/a | yes |
+| target_vpc_id | ID of the target VPC | `string` | n/a | yes |
+| tags | AWS tags to apply to the created resources | `map(string)` | <pre>{<br>  "installer": "terraform",<br>  "maintainer": "skyscrapers"<br>}</pre> | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| vpc_peering_id | ID of the VPC peering connection |
+
 ## securitygroups/all
 
 This module creates and exposes a reusable security group called `sg-all`.

--- a/vpc_peering/main.tf
+++ b/vpc_peering/main.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  alias = "source"
+}
+
+provider "aws" {
+  alias = "target"
+}
+
+data "aws_vpc" "source" {
+  provider = aws.source
+  id       = var.source_vpc_id
+}
+
+data "aws_vpc" "target" {
+  provider = aws.target
+  id       = var.target_vpc_id
+}

--- a/vpc_peering/outputs.tf
+++ b/vpc_peering/outputs.tf
@@ -1,0 +1,4 @@
+output "vpc_peering_id" {
+  description = "ID of the VPC peering connection"
+  value       = aws_vpc_peering_connection.peering.id
+}

--- a/vpc_peering/routes.tf
+++ b/vpc_peering/routes.tf
@@ -1,0 +1,17 @@
+resource "aws_route" "source_to_target" {
+  provider = aws.source
+  for_each = toset(var.source_route_table_ids)
+
+  route_table_id            = each.value
+  destination_cidr_block    = data.aws_vpc.target.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peering.id
+}
+
+resource "aws_route" "target_to_source" {
+  provider = aws.target
+  for_each = toset(var.target_route_table_ids)
+
+  route_table_id            = each.value
+  destination_cidr_block    = data.aws_vpc.source.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peering.id
+}

--- a/vpc_peering/variables.tf
+++ b/vpc_peering/variables.tf
@@ -1,0 +1,43 @@
+variable "target_account_id" {
+  type        = string
+  description = "AWS account id of the target VPC"
+}
+
+variable "target_vpc_id" {
+  type        = string
+  description = "ID of the target VPC"
+}
+
+variable "target_name" {
+  type        = string
+  description = "Name of the target VPC"
+}
+
+variable "target_route_table_ids" {
+  type        = list(string)
+  description = "List of route table IDs from the target VPC that should be routable to the source VPC"
+}
+
+variable "source_vpc_id" {
+  type        = string
+  description = "ID of the source VPC"
+}
+
+variable "source_name" {
+  type        = string
+  description = "Name of the source VPC"
+}
+
+variable "source_route_table_ids" {
+  type        = list(string)
+  description = "List of route table IDs from the source VPC that should be routable to the target VPC"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "AWS tags to apply to the created resources"
+  default = {
+    installer  = "terraform"
+    maintainer = "skyscrapers"
+  }
+}

--- a/vpc_peering/vpc-peering.tf
+++ b/vpc_peering/vpc-peering.tf
@@ -1,0 +1,39 @@
+resource "aws_vpc_peering_connection" "peering" {
+  provider      = aws.source
+  peer_owner_id = var.target_account_id
+  peer_vpc_id   = var.target_vpc_id
+  vpc_id        = var.source_vpc_id
+  auto_accept   = false
+
+  tags = merge(var.tags, {
+    Name = "VPC Peering between ${var.source_name} and ${var.target_name} VPCs"
+  })
+}
+
+resource "aws_vpc_peering_connection_accepter" "peering" {
+  provider                  = aws.target
+  vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
+  auto_accept               = true
+
+  tags = merge(var.tags, {
+    Name = "VPC Peering between ${var.source_name} and ${var.target_name} VPCs"
+  })
+}
+
+resource "aws_vpc_peering_connection_options" "peering_requester" {
+  provider                  = aws.source
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peering.id
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+
+resource "aws_vpc_peering_connection_options" "peering_accepter" {
+  provider                  = aws.target
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peering.id
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+}


### PR DESCRIPTION
Added a simple vpc peering module. It creates the VPC peering resources on both sides of the connection and creates the necessary routes.
It requires two AWS providers in order to configure both VPCs