### PR TITLE
Remove default tags from vpc_peering

### DIFF
--- a/vpc_peering/variables.tf
+++ b/vpc_peering/variables.tf
@@ -36,8 +36,4 @@ variable "source_route_table_ids" {
 variable "tags" {
   type        = map(string)
   description = "AWS tags to apply to the created resources"
-  default = {
-    installer  = "terraform"
-    maintainer = "skyscrapers"
-  }
 }

--- a/vpc_peering/variables.tf
+++ b/vpc_peering/variables.tf
@@ -36,4 +36,5 @@ variable "source_route_table_ids" {
 variable "tags" {
   type        = map(string)
   description = "AWS tags to apply to the created resources"
+  default     = {}
 }


### PR DESCRIPTION
We shouldn't force these tags. For internal use we set them already through the provider tags.