### PR TITLE
Fix provider syntax for vpc_peering

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ No modules.
 | <a name="input_target_name"></a> [target_name](#input_target_name) | Name of the target VPC | `string` | n/a | yes |
 | <a name="input_target_route_table_ids"></a> [target_route_table_ids](#input_target_route_table_ids) | List of route table IDs from the target VPC that should be routable to the source VPC | `list(string)` | n/a | yes |
 | <a name="input_target_vpc_id"></a> [target_vpc_id](#input_target_vpc_id) | ID of the target VPC | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input_tags) | AWS tags to apply to the created resources | `map(string)` | <pre>{<br>  "installer": "terraform",<br>  "maintainer": "skyscrapers"<br>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input_tags) | AWS tags to apply to the created resources | `map(string)` | `{}` | no |
 
 ### Outputs
 

--- a/vpc_peering/main.tf
+++ b/vpc_peering/main.tf
@@ -1,9 +1,13 @@
-provider "aws" {
-  alias = "source"
-}
-
-provider "aws" {
-  alias = "target"
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      configuration_aliases = [
+        aws.source,
+        aws.target,
+      ]
+    }
+  }
 }
 
 data "aws_vpc" "source" {


### PR DESCRIPTION
Fixes

```
│ Warning: Redundant empty provider block
│
│   on .terraform/modules/eks_legacy_int/vpc_peering/main.tf line 1:
│    1: provider "aws" {
```